### PR TITLE
Update and rename SPDX_documnent.md to SPDX_document.md

### DIFF
--- a/content/en/docs/Userguide/SPDX_document.md
+++ b/content/en/docs/Userguide/SPDX_document.md
@@ -1,9 +1,9 @@
 ---
-linkTitle: "SPDX Documnent"
-title: "SPDX Documnent"
+linkTitle: "SPDX Document"
+title: "SPDX Document"
 weight: 100
 description: 
-  SPDX Documnent
+  SPDX Document
 ---
 
 # **How to enable this feature**


### PR DESCRIPTION
The page name contained a spelling. This is corrected in the document file and in its metadata.