### PR TITLE
chore(docs): add DCO and Breaking changes guides

### DIFF
--- a/content/en/docs/Development/Dev-Semantic-Commits.md
+++ b/content/en/docs/Development/Dev-Semantic-Commits.md
@@ -9,7 +9,11 @@ weight: 10
 - simple navigation through git history (e.g. ignoring style changes)
 
 ## Semantic commit message structure
-`<type>(<scope>): <commit message>`
+```
+<type>(<scope>): <commit message>
+
+Signed-off-by: Name <email address>
+```
 
 ## The following <types> are supported
 - feat (new feature for the user, not a new feature for build script)
@@ -30,9 +34,11 @@ Example <scope> values:
 - etc.
 
 ## Example of semantic commit message
-`fix(rest): change maven plugin order to generate the documentation correctly`
+```
+fix(rest): change maven plugin order to generate the documentation correctly
 
-`<type>(<scope>): <commit message>`
+Signed-off-by: John Doe <john.doe@example.com>
+```
 
 ## Referencing issues
 Please reference in the pull request to the open issue
@@ -40,3 +46,19 @@ Please reference in the pull request to the open issue
 `closes eclipse/sw360#<issue-number>`
 
 `closes eclipse/sw360#758`
+
+## Breaking changes
+If a commit is introducing a breaking change in a functionality or an endpoint,
+it must be documented in the commit message by adding an exclamation `!` after
+the commit type. Additional documentation for the break can be added to the
+commit footer with a `BREAKING CHANGE:` message.
+
+### Example of commit with breaking change
+```
+fix(rest)!: migrate health endpoint
+
+BREAKING CHANGE: Move the health endpoint from `/resource/health` to
+`/resource/api/health`.
+
+Signed-off-by: John Doe <john.doe@example.com>
+```


### PR DESCRIPTION
Add suggestions to use DCO while creating a commits.

Also, added ways to document a breaking change in commit.