### PR TITLE
Updated slack joining link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -125,7 +125,7 @@ desc = "Development takes place here!"
 
 [[params.links.developer]]
 name = "Slack"
-url = "https://sw360chat.slack.com"
+url = "https://join.slack.com/t/sw360chat/shared_invite/enQtNzg5NDQxMTQyNjA5LThiMjBlNTRmOWI0ZjJhYjc0OTk3ODM4MjBmOGRhMWRmN2QzOGVmMzQwYzAzN2JkMmVkZTI1ZjRhNmJlNTY4ZGI"
 icon = "fab fa-slack"
 desc = "Chat with other project developers"
 


### PR DESCRIPTION
**Description:**
This PR updates the Slack joining link to ensure that new contributors can easily access the Pharo community workspace.

**Changes:**
Replaced the outdated Slack invitation link with the latest one.
