### PR TITLE
Gsoc doc glitch resolved

### DIFF
--- a/content/en/gsoc/GSoC-projects-2025.md
+++ b/content/en/gsoc/GSoC-projects-2025.md
@@ -80,7 +80,7 @@ https://github.com/eclipse-sw360/sw360/discussions/2868
 4. [Improve tests for all REST API endpoints](#improve-tests-for-all-rest-api-endpoints)
 5. [SBOM based recommendation](#sbom-based-recommendation)
 6. [Creating Project as a Service](#creating-project-as-a-service)
-7. []
+7. [Update Official Documentation Page](#update-official-documentation-page)
 
 ### License Change Detection
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/149dcc6c-2de7-4eca-acee-d113be0b73d9)

Update Official Documentation Page not mentioned on 7th **index** in proposal topics which is being fixed now.