### PR TITLE
feat(doc update): Update System Requirements Documentation (Ubuntu 22.04, OpenJDK 11, Link Fixes)

### DIFF
--- a/content/en/docs/Deployment/Deploy-Requirements.md
+++ b/content/en/docs/Deployment/Deploy-Requirements.md
@@ -6,84 +6,73 @@ description:
   SW360 minimal system requirements based on system class
 ---
 
-For deploying the SW360, there are the following hardware requirements below. Please note that the main memory consumer is the tomcat application container. Accordingly, this requires different settings (see `$TOMCAT_HOME/bin/setenv.sh`).
+For deploying SW360, the following hardware requirements are recommended. Please note that the main memory consumer is the Tomcat application container. Accordingly, this requires different settings (see `$TOMCAT_HOME/bin/setenv.sh`).
 
-Please note that you can review the current memory situation of the application in the liferay administration section as well (see `Configuration`-> `Server Administration`).
+Please note that you can review the current memory situation of the application in the Liferay administration section as well (see `Configuration` -> `Server Administration`).
 
 ## Hardware and Infrastructure
 
-### CD-based test instances
+### CD-based Test Instances
 
-When there is a continuous deployment and continuous delivery directly deployed to machine the following machine is recommended:
+For continuous deployment and continuous delivery directly deployed to a machine, the following specifications are recommended:
 
-* 1 core
-* 4GB RAM
-* 40GB normal file system
-* 10Mbit Ethernet link
+- 1 core
+- 4GB RAM
+- 40GB normal file system
+- 10Mbit Ethernet link
 
-In this case, the sw360 solution runs fairly well for clicking around and creation of a few data sets. Note that Tomcat should have 2GB.
+In this case, the SW360 solution runs fairly well for basic interactions and the creation of a few data sets. Note that Tomcat should have 2GB allocated.
 
-### Staging instances
+### Staging Instances
 
-Testing and working with normal data sets for staging and pre-productive testing. Pre productive does not need to have the same execution speed of the machine, however, requires enough RAM and file system to run a clone on the data set.
+For testing and working with normal data sets in staging and pre-production environments. Pre-production does not need to have the same execution speed as the production environment; however, it requires enough RAM and file system capacity to run a clone of the data set.
 
-* 2 cores
-* 8GB RAM
-* 500GB normal file system
-* 100Mbit Ethernet link
+- 2 cores
+- 8GB RAM
+- 500GB normal file system
+- 100Mbit Ethernet link
 
-The tomcat should be adjusted to 4GB RAM
+Tomcat should be adjusted to 4GB RAM.
 
-### Productive instances
+### Productive Instances
 
-Productive with for example: 10K releases, 2k users which deploys the entire solution onto a single larger machine. It does not apply to a docker based setup.
+For production environments with, for example, 10K releases and 2K users, deploying the entire solution onto a single larger machine is recommended. This does not apply to a Docker-based setup.
 
-* 4 cores
-* 16GB RAM
-* 500GB SSD based file system
-* 1GBit link Ethernet link
+- 4 cores
+- 16GB RAM
+- 500GB SSD-based file system
+- 1GBit Ethernet link
 
-Tomcat should be adjusted to 10-12GB RAM. Note: normally, you could also run Tomcat with significantly lees RAM, if you put common dependencies in a shared lib folder.
+Tomcat should be adjusted to 10-12GB RAM. Note: Normally, you could also run Tomcat with significantly less RAM if you place common dependencies in a shared lib folder.
 
 ### Network
 
-The following table shall give an overview about the inbound ports
+The following table provides an overview of the inbound ports:
 
-| Port | Service | Remarks|
-|:-----------|:------------|:------------|
-| 443 | https | Accessing the application |
-| 22  | ssh | Administering the application |
-| 80 | http | if you would like to access the solution over http |
-| 5984/5985 | http/https | if access to the couchdb (admin) interface is required |
+| Port | Service | Remarks                               |
+|------|---------|---------------------------------------|
+| 443  | https   | Accessing the application             |
+| 22   | ssh     | Administering the application         |
+| 80   | http    | If you would like to access over http |
+| 5984 | http    | If access to the CouchDB (admin) interface is required |
+| 5985 | https   | If access to the CouchDB (admin) interface is required |
 
-Overview about the *additional* outbound ports:
+Overview of the *additional* outbound ports:
 
-| Port | Service | Remarks|
-|:-----------|:------------|:------------|
-| 3269 | sldap | If you do authentication using secure LDAP |
-| 443 | sldap | If you do consume services over https (e.g. vulnerabilty pulling) |
-| 53 | dns | ... |
-| 22 | ssh | the old way of calling a fossology server |
+| Port | Service | Remarks                                                      |
+|------|---------|--------------------------------------------------------------|
+| 3269 | sldap   | If you do authentication using secure LDAP                   |
+| 443  | https   | If you consume services over https (e.g., vulnerability pulling) |
+| 53   | dns     | ...                                                          |
+| 22   | ssh     | The old way of calling a FOSSology server                    |
 
-Outbound ports for http / https may be required for downloading system updates. Ports for ssh may not be required outbound.
+Outbound ports for http/https may be required for downloading system updates. Ports for ssh may not be required outbound.
 
-## Software:
+## Software
 
-As for the software, the sw360 can be run on many platforms, even on Windows seven. We have the following reference platform for development:
+SW360 can run on many platforms. The following reference platforms are recommended:
 
-until 5:
+- **OpenJDK 11**
+- **Ubuntu 22.04 LTS**
 
-* OpenJDK 8
-* Unbunu 16.04 LTS
-
-after 5:
-
-* openjdk 8
-* ubuntu 18.04 LTS
-
-after 11:
-
-* openjdk 11
-* ubuntu 18.04 LTS
-
-More information about requirements can be found here: https://github.com/sw360/sw360vagrant/wiki
+More information about requirements can be found here: [https://github.com/eclipse/sw360vagrant/wiki](https://github.com/eclipse/sw360vagrant/wiki)


### PR DESCRIPTION
**Description**:
This PR updates the System Requirements documentation to correct outdated information and improve clarity while maintaining functionality.

**Changes Introduced**:

-  Updated Software Requirements:

**Changed Ubuntu 16.04/18.04 LTS → Ubuntu 22.04 LTS (latest supported LTS version).**
**why** ??
Ubuntu 16.04 LTS and 18.04 LTS are outdated and no longer supported.

Standardized OpenJDK versions to OpenJDK 11 (recommended).

-  Fixed Outdated SW360 Vagrant Documentation Link:

**Updated the old GitHub link to the latest Eclipse SW360 Vagrant Wiki.**

-  Grammar & Readability Improvements:

Reworded some sections for better clarity without changing functionality.
**Fixed typos** (e.g., “lees” → “less”) and improved consistency.

-  Standardized Network Ports Section Formatting: