### PR TITLE
docs(Corrected the link to install-thrift.sh script in SW360)

### DIFF
--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../deploy-keycloak-authentication/)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../deploy-configuration-files/)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -89,7 +89,7 @@ sudo apt-get install -y temurin-21-jdk
 
 ### 1.3. Thrift
 
-For thrift, the helper install script is located on sw360 `scripts/install-thrift.sh`:
+To install Apache Thrift using the helper script in the SW360 project, run the install-thrift.sh script located in `third-party/thrift/install-thrift.sh`: [here](https://github.com/eclipse-sw360/sw360/blob/d7869d252c4b4c84e6ee389cbed44543cd37f7ac/third-party/thrift/install-thrift.sh)
 
 ```bash
 sudo ./scripts/install-thrift.sh


### PR DESCRIPTION
The script's location has been specified, and the file path has been corrected.

In the deployed SW360 website, both [Keycloak-based authentication] and [Configurable Property Keys] were previously leading users to error pages. These links have now been fixed and correctly direct users to their intended destinations.

![Version 19 x on Debian 12 _ Eclipse SW360 - Google Chrome 17-03-2025 21_12_15](https://github.com/user-attachments/assets/805dd12b-4049-460e-991b-fca90e57bd8f)

![Not Found - Google Chrome 17-03-2025 21_09_13](https://github.com/user-attachments/assets/f5262d40-f111-4db8-96a4-f93c157687f3)


