### PR TITLE
Implemented a fully functional news page

### DIFF
--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../deploy-keycloak-authentication/)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../deploy-configuration-files/)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -89,7 +89,7 @@ sudo apt-get install -y temurin-21-jdk
 
 ### 1.3. Thrift
 
-For thrift, the helper install script is located on sw360 `scripts/install-thrift.sh`:
+To install Apache Thrift using the helper script in the SW360 project, run the install-thrift.sh script located in `third-party/thrift/install-thrift.sh`: [here](https://github.com/eclipse-sw360/sw360/blob/d7869d252c4b4c84e6ee389cbed44543cd37f7ac/third-party/thrift/install-thrift.sh)
 
 ```bash
 sudo ./scripts/install-thrift.sh

--- a/content/en/news/2022/eclipse-con-2022.md
+++ b/content/en/news/2022/eclipse-con-2022.md
@@ -1,0 +1,46 @@
+---
+title: SW360 at EclipseCon 2022 in Ludwigsburg, Germany
+linkTitle: SW360 at EclipseCon 2022
+date: 2022-11-25
+---
+
+#### Presented by **Helio Chissini de Castro** (BMW Group) at EclipseCon 2022.
+
+
+{{< youtube sbCwuV6iuOM >}}
+
+---
+## Overview
+This talk covered insights from an experienced open-source engineer **Helio Chissini de Castro** with over 25 years in the field. As a core developer in SW360, the speaker shared thoughts on evolving technologies, compliance challenges, and the future of software development.
+
+## Key Takeaways
+
+- **Passion for Fun and Innovation**  
+  Emphasizes enjoyable coding and staying ahead with evolving technologies.
+  
+- **Challenges in Compliance Software**  
+  Compliance solutions require major improvements as existing tools remain incomplete.
+  
+- **New Industry Standards**  
+  Open compliance groups are working on defining modern standards.
+  
+- **Need for Better Integration & Authentication**  
+  Modernizing these aspects is crucial for efficiency and security.
+  
+- **Continuous Improvement in Development**  
+  The software landscape demands constant enhancements and refinements.
+  
+- **Unified Installation Approach**  
+  A single, streamlined installation process is necessary to reduce complexity.
+  
+- **Upgrading Core Technologies**  
+  Significant updates to underlying software and libraries are required.
+   
+- **Collaborative Development**  
+  Partnering with multiple companies to achieve common goals.
+  
+- **Community Contributions**  
+  Encouraging wider participation to drive innovation and improvement.
+
+## Conclusion
+The talk highlighted the importance of continuous innovation, improving compliance software, and fostering community collaboration. By embracing new standards and modernizing technology, open-source projects like SW360 can remain at the forefront of development.

--- a/content/en/news/2022/updates-2022.md
+++ b/content/en/news/2022/updates-2022.md
@@ -1,0 +1,29 @@
+---
+title: SW360 in 2022 Key Updates and Developments
+linkTitle: Key Updates and Developments 
+date: 2022-01-12
+
+---
+
+## New Features for OSS License and SBOM Management
+SW360 introduced capabilities to manage Open Source Software (OSS) license obligations and Software Bill of Materials (SBOM) using the Software Package Data Exchange (SPDX) format. These enhancements aimed to simplify the integration of SW360 with other tools and improve the management of software components. ([Source](https://archive.fosdem.org/2022/schedule/event/how_to_manage_oss_license_obligation_and_sbom_using_sw360_new_features/?utm_source=chatgpt.com))
+
+### Project Lead Election
+In May 2022, Kouki Hama was elected as a new project lead for SW360. Kouki had been actively contributing to SW360 by generating content, presenting at events, and maintaining the project's GitHub repository. ([Source](https://www.eclipse.org/lists/sw360-dev/msg00390.html?utm_source=chatgpt.com))
+
+### Presentation at FOSDEM 2022
+SW360 was featured in a presentation titled *"How to manage OSS license obligations and SBOM by SW360's new features"* during the Software Composition and Dependency Management devroom at FOSDEM 2022. This presentation highlighted SW360's advancements in managing OSS licenses and SBOMs. ([Source](https://archive.fosdem.org/2022/schedule/track/software_composition_and_dependency_management/?utm_source=chatgpt.com))
+
+### Additional Feature Enhancements
+
+Throughout 2022, SW360 introduced several notable features:
+
+- **CouchDB-Lucene Integration**: Added support for full-text search capabilities by integrating CouchDB-Lucene as a third-party library. This enhancement improved the search functionality within SW360. 
+- **REST API Documentation Updates**: Updated REST API documentation to include comprehensive details on components, facilitating better integration with external tools and services. 
+
+- **SPDX Data Display**: Introduced a new tab in component release pages to display SPDX/SPDX Lite data, enhancing transparency and compliance tracking. 
+
+
+---
+These developments underscore SW360's commitment to enhancing software component management and fostering community engagement within the open-source ecosystem.
+

--- a/content/en/news/2023/eclipse-con-2023 .md
+++ b/content/en/news/2023/eclipse-con-2023 .md
@@ -1,0 +1,49 @@
+---
+title: SW360 at EclipseCon 2023 in Ludwigsburg, Germany
+linkTitle: SW360 at EclipseCon 2023
+date: 2023-10-18
+---
+
+##### Presented at EclipseCon 2023 in Ludwigsburg, Germany by Kouki Hama (Toshiba Corporation), Katharina Ettinger (Siemens AG) and Arun Azhakesan (Siemens AG).
+
+{{< youtube iJkyO7nJZaw >}}
+
+---
+
+## Key Takeaways from the Presentation on Software 360  
+
+### Introduction to S360
+- **Centralized software management tool** for tracking components, licenses, and vulnerabilities.
+- Designed to **simplify software compliance and security** in open-source and enterprise environments.
+
+### Key Features
+- **Component Registration**: Tracks software details such as name, type, version, and licensing information.
+- **Project Hierarchy Management**: Enables project visibility across multiple levels, including sub-projects.
+- **Advanced Search Functions**: Allows users to locate projects and components efficiently.
+
+### Adoption Process
+- **Quick and simple setup** through a three-step process.
+- **Flexible for all organization sizes**, from startups to large enterprises.
+
+### License Compliance Support
+- Supports **Cyclone DX and SPDX** formats for Software Bill of Materials (SBOM).
+- Helps ensure adherence to **various open-source licensing standards**.
+
+### Real-World Applications
+- **Tosa leverages S360** for license compliance and integrating existing obligations.
+- **API integration** allows organizations to connect S360 with existing tools and databases.
+- Customizable functionalities to adapt to **language and project-specific requirements**.
+
+### Automation & Efficiency
+- **Streamlined approval workflows** for open-source software licensing.
+- Supports **CI/CD pipelines** for automated component registration and updates.
+
+### Security & Vulnerability Management
+- **Third-party tool integrations** for vulnerability scanning.
+- Provides **detailed oversight of dependency security risks**.
+
+### Community Engagement
+- Encourages participation in **community discussions and meetings**.
+- Promotes **collaboration and innovation** among software professionals.
+
+This presentation emphasizes best practices in software management and demonstrates the adaptability of S360 to various organizational needs while promoting community collaboration for continuous improvement.

--- a/content/en/news/2023/eclipse-con-2023.md
+++ b/content/en/news/2023/eclipse-con-2023.md
@@ -1,0 +1,49 @@
+---
+title: SW360 at EclipseCon 2023 in Ludwigsburg, Germany
+linkTitle: SW360 at EclipseCon 2023
+date: 2023-10-18
+---
+
+##### Presented at EclipseCon 2023 in Ludwigsburg, Germany by Kouki Hama (Toshiba Corporation), Katharina Ettinger (Siemens AG) and Arun Azhakesan (Siemens AG).
+
+{{< youtube iJkyO7nJZaw >}}
+
+---
+
+## Key Takeaways from the Presentation on Software 360  
+
+### Introduction to S360
+- **Centralized software management tool** for tracking components, licenses, and vulnerabilities.
+- Designed to **simplify software compliance and security** in open-source and enterprise environments.
+
+### Key Features
+- **Component Registration**: Tracks software details such as name, type, version, and licensing information.
+- **Project Hierarchy Management**: Enables project visibility across multiple levels, including sub-projects.
+- **Advanced Search Functions**: Allows users to locate projects and components efficiently.
+
+### Adoption Process
+- **Quick and simple setup** through a three-step process.
+- **Flexible for all organization sizes**, from startups to large enterprises.
+
+### License Compliance Support
+- Supports **Cyclone DX and SPDX** formats for Software Bill of Materials (SBOM).
+- Helps ensure adherence to **various open-source licensing standards**.
+
+### Real-World Applications
+- **Tosa leverages S360** for license compliance and integrating existing obligations.
+- **API integration** allows organizations to connect S360 with existing tools and databases.
+- Customizable functionalities to adapt to **language and project-specific requirements**.
+
+### Automation & Efficiency
+- **Streamlined approval workflows** for open-source software licensing.
+- Supports **CI/CD pipelines** for automated component registration and updates.
+
+### Security & Vulnerability Management
+- **Third-party tool integrations** for vulnerability scanning.
+- Provides **detailed oversight of dependency security risks**.
+
+### Community Engagement
+- Encourages participation in **community discussions and meetings**.
+- Promotes **collaboration and innovation** among software professionals.
+
+This presentation emphasizes best practices in software management and demonstrates the adaptability of S360 to various organizational needs while promoting community collaboration for continuous improvement.

--- a/content/en/news/2024/version-19.1.0.md
+++ b/content/en/news/2024/version-19.1.0.md
@@ -1,0 +1,33 @@
+---
+title: Latest Version 19.1.0 Release
+linkTitle: Version 19.1.0 Release
+date: 2024-12-16
+---
+#### This minor release includes numerous features, corrections, and improvements across the SW360 project since the 19.0.0 release.
+
+#### Highlight of the changes includes:
+- Various vulnerabilities and security fixes.  
+- Multiple new REST API endpoints.  
+- Improvements on SBOM and CDX import.  
+
+## Credits  
+The following GitHub users have contributed to the source code since the last release (in alphabetical order):  
+
+- **Afsah Syeda** (<afsah.syeda@siemens-healthineers.com>)  
+- **Akshit Joshi** (<akshit.joshi@siemens-healthineers.com>)  
+- **Arun Azhakesan** (<arun.azhakesan@siemens-healthineers.com>)  
+- **duonglq-tsdv** (<duong1.lequy@toshiba.co.jp>)  
+- **Gaurav Mishra** (<mishra.gaurav@siemens.com>)  
+- **Helio Chissini de Castro** (<heliocastro@gmail.com>)  
+- **hoangnt2** (<hoang2.nguyenthai@toshiba.co.jp>)  
+- **Keerthi B L** (<keerthi.bl@siemens.com>)  
+- **Nikesh Kumar** (<kumar.nikesh@siemens.com>)  
+- **Rudra Chopra** (<prabhuchopra@gmail.com>)  
+- **Sameed** (<sameed.ahmad@siemens-healthineers.com>)  
+- **Smruti Prakash Sahoo** (<smruti.sahoo@siemens.com>)  
+- **StepSecurity Bot** (<bot@stepsecurity.io>)  
+- **tuannn2** (<tuan2.nguyennhu@toshiba.co.jp>)  
+
+Please note that also many other persons usually contribute to the project with reviews, testing, documentations, conversations or presentations.
+
+#### Read the entire info about the release [here](https://github.com/eclipse-sw360/sw360/releases/tag/sw360-19.1.0)

--- a/content/en/news/_index.md
+++ b/content/en/news/_index.md
@@ -1,0 +1,8 @@
+---
+title: "SW360 Latest News & Updates"
+linkTitle: "News"
+menu:
+    main:
+        weight: 50
+---
+

--- a/layouts/news/baseof.html
+++ b/layouts/news/baseof.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }} td-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ with .CurrentSection.OutputFormats.Get "rss" -}}
+            <a class="td-rss-button" title="RSS" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
+              <i class="fa-solid fa-rss" aria-hidden="true"></i>
+            </a>
+            {{ end -}}
+            {{ if not (.Param "ui.breadcrumb_disable") -}}
+              {{ partial "breadcrumb.html" . -}}
+            {{ end -}}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/news/baseof.print.html
+++ b/layouts/news/baseof.print.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }} td-blog">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+          </div>
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+          </div>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/news/content.html
+++ b/layouts/news/content.html
@@ -1,0 +1,24 @@
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<div class="td-byline mb-4">
+		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
+		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-body-secondary">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
+	</div>
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+			{{ partial "reading-time.html" . -}}
+		{{ end -}}
+	</header>
+	{{ .Render "td-content-after-header" -}}
+	{{ .Content }}
+	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
+		<br />
+		{{- partial "disqus-comment.html" . -}}
+		<br />
+	{{ end -}}
+
+	{{ partial "pager.html" . }}
+	{{ partial "page-meta-lastmod.html" . -}}
+</div>

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -1,0 +1,45 @@
+{{ define "main" -}}
+
+<div class="td-content">
+<h1>{{ .Title }}</h1>
+{{ with .Content }}{{ . }}{{ end -}}
+</div>
+{{ if (and .Parent .Parent.IsHome) -}}
+  {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) -}}
+{{ else -}}
+  {{$.Scratch.Set "blog-pages" .Pages -}}
+{{ end -}}
+
+{{ if .Pages -}}
+<div class="td-blog-posts">
+  {{ $pager := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
+  {{ range $pager.PageGroups -}}
+  <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
+  <ul class="td-blog-posts-list">
+    {{ range .Pages -}}
+    <li class="td-blog-posts-list__item">
+      <div class="td-blog-posts-list__body">
+        <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+        <p class="mb-2 mb-md-3"><small class="text-body-secondary">
+          {{- .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle -}}
+        </small></p>
+        <header class="article-meta">
+          {{- partial "taxonomy_terms_article_wrapper.html" . -}}
+          {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+            {{- partial "reading-time.html" . -}}
+          {{ end -}}
+        </header>
+        {{- partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
+        <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+        <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
+      </div>
+    </li>
+    {{ end -}}
+  </ul>
+  {{ end -}}
+</div>
+<div class="td-blog-posts__pagination">
+  {{ template "_internal/pagination.html" . -}}
+</div>
+{{- end -}}
+{{ end -}}

--- a/layouts/news/section.print.html
+++ b/layouts/news/section.print.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "print/render"  . }}
+{{ end }}

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ .Render "content" }}
+{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,7 +1,7 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }} flex-column flex-md-row td-navbar">
-        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}"
+        <a class="navbar-brand flex-shrink-0" href="{{ .Site.Home.RelPermalink }}"
 		{{ if eq .Page.Title "SW360" }} 
 			{{ if $cover }}
 				style="display: none;" 
@@ -10,8 +10,8 @@
 		>			
 		{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}
 	</a>
-	<div class="td-navbar-nav-scroll ml-md-auto ms-md-auto" id="main_navbar">
-		<ul class="navbar-nav">
+	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
+		<ul class="navbar-nav mt-2 mt-lg-0">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
@@ -27,12 +27,12 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mx-2">
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
-			<li class="nav-item dropdown mx-2">
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
 				{{ partial "navbar-lang-selector.html" . }}
 			</li>
 			{{ end }}
@@ -40,5 +40,3 @@
 	</div>
 	<div class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
 </nav>
-
-

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,7 +1,7 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }} flex-column flex-md-row td-navbar">
-        <a class="navbar-brand flex-shrink-0" href="{{ .Site.Home.RelPermalink }}"
+        <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}"
 		{{ if eq .Page.Title "SW360" }} 
 			{{ if $cover }}
 				style="display: none;" 
@@ -10,8 +10,8 @@
 		>			
 		{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}
 	</a>
-	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
-		<ul class="navbar-nav mt-2 mt-lg-0">
+	<div class="td-navbar-nav-scroll ml-md-auto ms-md-auto" id="main_navbar">
+		<ul class="navbar-nav">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
@@ -27,12 +27,12 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+			<li class="nav-item dropdown mx-2">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
-			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+			<li class="nav-item dropdown mx-2">
 				{{ partial "navbar-lang-selector.html" . }}
 			</li>
 			{{ end }}
@@ -40,3 +40,5 @@
 	</div>
 	<div class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
 </nav>
+
+


### PR DESCRIPTION
### Fixes #17 
### Integrated a dedicated News section into the navigation menu.

Here's the corresponding implementation in the source code.
```
sw360.website/
├── content/               
│   ├── en/                
│   │   ├── news/          
│   │   │   ├── 2022/      
│   │   │   ├── 2023/      
│   │   │   ├── 2024/      
│   │   │   ├── _index.md  
├── layouts/               
│   ├── news/              
│   │   ├── baseof.html    
│   │   ├── baseof.print.html  
│   │   ├── content.html   
│   │   ├── list.html      
│   │   ├── section.print.html  
│   │   ├── single.html    
```
### Attached are images and a video showcasing the implementation.

![Eclipse SW360 - Google Chrome 25-03-2025 23_54_40](https://github.com/user-attachments/assets/29c483aa-d304-4c3a-ab37-a8e5ce20b951)

![Eclipse SW360 - Google Chrome 25-03-2025 23_58_49](https://github.com/user-attachments/assets/54886591-9d4e-4b1b-aa51-30a66e727970)

![Eclipse SW360 - Google Chrome 26-03-2025 00_01_34](https://github.com/user-attachments/assets/716f57db-b9df-428d-a072-9f3fc7a6ef28)


https://github.com/user-attachments/assets/f0845470-00ad-448e-aa0b-980fd8103314



