### PR TITLE
Fixed Broken Links in Administration Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-# sw360.website
+<p align="center">
+  <a href="https://eclipse.dev/sw360/">
+   <img src="static/img/logos/logo_full.svg" alt="SW360 Logo" width="450">
+  </a>
+    <h1 align="center">sw360.website</h1>
+  
+  <p align="center">
+    <a href="https://eclipse.dev/sw360/"><strong>Learn more »</strong></a>
+    <br />
+    <br />
+    <a href="https://sw360chat.slack.com/">Discussions</a>
+    ·
+    <a href="https://eclipse.dev/sw360/">Website</a>
+    ·
+    <a href="https://github.com/eclipse-sw360/sw360.website/issues">Issues</a>
+    .
+    <a href="https://eclipse.dev/sw360/docs/">Documentation</a>
+    ·
+    <a href="https://eclipse.dev/sw360/gsoc/">GSoC</a>
+  </p>
+</p>
 
 The website is based on the Hugo static page generator. 
 All relevant source files can be found at github/sw360.website (https://github.com/eclipse/sw360.website). 
@@ -13,19 +33,85 @@ The result of the jenkins build is pushed to: http://git.eclipse.org/c/www.eclip
 
 The jenkins jobs looks every 15 minutes after changes on the repository. If it detects changes it will start the hugo build and copy the generated static html files to git.eclipse.org. From there another job fetches the files and copies them to the actual static webspace of the Eclipse Foundation.
 
-## Docker local live testing
+## Table of Contents
 
-If you have docker installed on your system, you can test in realtime all changes.
+- [Prerequisites](#prerequisites)
+- [Local Development Using Docker](#local-development-using-docker)
+- [Troubleshooting](#troubleshooting)
+- [Project Structure](#project-structure)
+- [Support](#support)
 
-In a terminal, run:
+## Prerequisites
 
-```sh
-bash docker_serve_local.sh
+Ensure you have the following installed before proceeding:
+
+- **Docker** (Check installation by running `docker --version` in the terminal)
+- **Bash** (Available by default on macOS and Linux; for Windows, use Git Bash or WSL)
+
+## Local Development Using Docker
+
+If you have Docker installed on your system, you can quickly set up a local development environment and test changes in real time.
+
+## Setting Up the Local Server
+
+1. Open a terminal and navigate to the project root directory.
+
+2. Run the following command to start the local server:
+
+   ```sh
+   bash docker_serve_local.sh
+   ```
+
+3. Once the server starts, open your browser and visit:
+
+   ```sh
+   http://localhost:1313/sw360
+   ```
+
+4. Any changes made to the code will automatically reflect in the browser.
+
+## Troubleshooting
+
+### 1. Docker is not running
+
+**Issue:** `bash: docker: command not found`
+
+**Solution:**
+
+- Ensure Docker is installed and running.
+- On macOS or Windows, open Docker Desktop.
+- On Linux, start Docker with:
+  ```sh
+  sudo systemctl start docker
+  ```
+
+### 2. Permission issues running the script
+
+**Issue:** `Permission denied` error when executing `docker_serve_local.sh`. 
+
+**Solution:**
+
+- Give execution permission to the script:
+  ```sh
+  chmod +x docker_serve_local.sh
+  ```
+- Run it again:
+  ```sh
+  bash docker_serve_local.sh
+  ```
+
+## Project Structure
 ```
-then open your browser on following URL:
-
-```sh
-http://localhost:1313/sw360
+sw360.website/
+├── content/               # Website content (pages, posts, etc.)
+├── layouts/               # Custom layout templates
+├── static/                # Static assets (images, CSS, JS)
+├── config.toml            # Hugo configuration
+├── docker_serve_local.sh  # Docker development script
+└── README.md              # Project documentation and contribution guidelines
 ```
+## Support
 
-All changes done in code will be refreshed in real time on the browser
+- Report issues: [GitHub Issues](https://github.com/eclipse/sw360.website/issues)
+- Community: [SW360 Mailing List](https://dev.eclipse.org/mailman/listinfo/sw360-dev)
+- Documentation: [SW360 Documentation](https://eclipse.dev/sw360/docs/)

--- a/content/en/docs/AdministrationGuide/User-Data-Model-Enumerations.md
+++ b/content/en/docs/AdministrationGuide/User-Data-Model-Enumerations.md
@@ -26,11 +26,11 @@ SW360 thrift API is comprised of the following methods:
 * vendors 
 * vulnerabilities 
 
-Reference: https://github.com/eclipse/sw360/tree/master/libraries/lib-datahandler/src/main/thrift
+Reference: https://github.com/eclipse-sw360/sw360/tree/main/libraries/datahandler/src/main/thrift
 
 ## Attachments
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/attachments.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/attachments.thrift
 
 ### AttachmentType
 
@@ -68,11 +68,11 @@ https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/
 
 ## Components 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/components.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/components.thrift
 
 ## cvesearch 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/cvesearch.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/cvesearch.thrift
 
 | Value  | Description |
 |---|---|
@@ -83,19 +83,19 @@ https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/
 
 ## Fossology 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/fossology.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/fossology.thrift
 
 _No enumerations provided_
 
 ## Importstatus 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/importstatus.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/importstatus.thrift
 
 _No enumerations provided_
 
 ## License Info 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/licenseinfo.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/licenseinfo.thrift
 
 _No enumerations provided_
 
@@ -116,13 +116,13 @@ _No enumerations provided_
 
 ## Licenses 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/licenses.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/licenses.thrift
 
 _No enumerations provided_
 
 ## Moderation 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/moderation.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/moderation.thrift
 
 ### DocumentType 
 
@@ -136,13 +136,13 @@ https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/
 
 ## Project Import 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/projectimport.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/projectimport.thrift
 
 _No enumerations provided_
 
 ## Projects 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/projects.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/projects.thrift
 
 ### Project State
 
@@ -181,13 +181,13 @@ https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/
 
 ## Schedule 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/schedule.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/schedule.thrift
 
 _No enumerations provided_
 
 ## Search 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/search.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/search.thrift
 
 _No enumerations provided_
 
@@ -259,16 +259,16 @@ _No enumerations provided_
 
 ## Users 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/users.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/users.thrift
 
 ## Vendors 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/vendors.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/vendors.thrift
 
 _No enumerations provided_
 
 ## Vulnerabilities 
 
-https://github.com/eclipse/sw360/blob/master/libraries/lib-datahandler/src/main/thrift/vulnerabilities.thrift
+https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/thrift/vulnerabilities.thrift
 
 _No enumerations provided_

--- a/content/en/docs/AdministrationGuide/properties.md
+++ b/content/en/docs/AdministrationGuide/properties.md
@@ -4,7 +4,7 @@ title: "Properties"
 weight: 12
 ---
 
-**Frontend Properties**: All the sw360 frontend properties are mentioned in [sw360.properties](https://github.com/eclipse/sw360/blob/master/frontend/sw360-portlet/src/main/resources/sw360.properties) file.
+**Frontend Properties**: All the sw360 frontend properties are mentioned in [sw360.properties](https://github.com/eclipse-sw360/sw360/blob/main/libraries/datahandler/src/main/resources/sw360.properties) file.
 For example;
 https://github.com/eclipse/sw360/wiki/
  - Different categories for components,
@@ -21,6 +21,6 @@ https://github.com/eclipse/sw360/wiki/
 
  - Activation of portlets and components
 
-**Backend Properties**: This, [sw360.properties](https://github.com/eclipse/sw360/blob/master/backend/src-common/src/main/resources/sw360.properties) file contains the sw360 backend properties. This file contains the common properties for the backend services and also holds the setting for the mail utility.
+**Backend Properties**: This, [sw360.properties](https://github.com/eclipse-sw360/sw360/blob/main/backend/common/src/main/resources/sw360.properties) file contains the sw360 backend properties. This file contains the common properties for the backend services and also holds the setting for the mail utility.
 
 You can change these default values by mentioning it in the sw360.properties file, present in /etc/sw360 folder. This path is to be created by the admin. After changing the properties, server needs to be restarted in order to make the changes effective. If the properties file is not present in the required folder, the default values will be selected.

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../deploy-keycloak-authentication/)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../deploy-configuration-files/)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -146,7 +146,7 @@ sudo apt install postgresql
 
 or whatever package version is suitable here, for example version 15 for Debian 12.
 
-Follow the [Keycloak based authentication](../Deploy-Keycloak-Authentication.md)
+Follow the [Keycloak based authentication](../../Deployment/Deploy-Keycloak-Authentication.md)
 guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
 
 ### 1.7. Clone and build sw360 version 19.x
@@ -155,7 +155,7 @@ guide to set up KeyCloak for SW360 after the installation from 1.8 is done.
     - `$ git clone https://github.com/eclipse-sw360/sw360.git`
 * Create config properties
     - `$ sudo mkdir -p /etc/sw360 /etc/sw360/autorization /etc/sw360/rest`
-    - Find the relevant configurations at [Configurable Property Keys](../Deploy-Configuration-Files.md)
+    - Find the relevant configurations at [Configurable Property Keys](../../Deployment/Deploy-Configuration-Files.md)
 * Compile and install the application
     - `$ mvn clean install -Dbase.deploy.dir=/opt/apache-tomcat-11.0.4/ -Dlistener.deploy.dir=/opt/keycloak-26.1.3/providers -P deploy`
 

--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -89,7 +89,7 @@ sudo apt-get install -y temurin-21-jdk
 
 ### 1.3. Thrift
 
-For thrift, the helper install script is located on sw360 `scripts/install-thrift.sh`:
+To install Apache Thrift using the helper script in the SW360 project, run the install-thrift.sh script located in `third-party/thrift/install-thrift.sh`: [here](https://github.com/eclipse-sw360/sw360/blob/d7869d252c4b4c84e6ee389cbed44543cd37f7ac/third-party/thrift/install-thrift.sh)
 
 ```bash
 sudo ./scripts/install-thrift.sh


### PR DESCRIPTION
This PR resolves all broken links that previously led to 404 errors on:

* https://eclipse.dev/sw360/docs/administrationguide/user-data-model-enumerations/
* https://eclipse.dev/sw360/docs/administrationguide/properties/

The issue was caused by links redirecting to the master branch, which has now been renamed to main.
All 18 affected links have been updated, verified, and tested locally to ensure they work correctly.

### Before

https://github.com/user-attachments/assets/2105dd12-154d-4885-bd63-6d49cb5036aa

### After

https://github.com/user-attachments/assets/17c16c05-fa9f-4043-b25a-5119e3e42f9c



