### PR TITLE
Fix(Docs): Broken Developer Meeting Link in Documentation

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -49,4 +49,4 @@ SW360 is
 | Developer mailing list | sw360-dev@eclipse.org | for developers, discussion about developing |
 | Slack Channel | https://sw360chat.slack.com/ | the main chat spot, everybody is welcome |
 | Slack Channel Invitation Link | [Sharable join link to join](https://join.slack.com/t/sw360chat/shared_invite/enQtNzg5NDQxMTQyNjA5LThiMjBlNTRmOWI0ZjJhYjc0OTk3ODM4MjBmOGRhMWRmN2QzOGVmMzQwYzAzN2JkMmVkZTI1ZjRhNmJlNTY4ZGI) | that should bring you in |
-| sw360 developer meeting | [Meeting Info](Developer-Meetings) | Everyone is welcome! |
+| sw360 developer meeting | [Meeting Info](https://github.com/eclipse-sw360/sw360/wiki/Developer-Meetings) | Everyone is welcome! |


### PR DESCRIPTION
- This PR updates the documentation to correct the broken link to the developer meeting. The previous link was no longer functional, and this update ensures users can access the correct meeting details.

**Before**
<img width="1710" alt="Screenshot 2025-04-08 at 10 08 49 PM" src="https://github.com/user-attachments/assets/0985e75d-e977-4b9f-9a42-042278b0857c" />



**After**
<img width="1710" alt="Screenshot 2025-04-08 at 10 11 07 PM" src="https://github.com/user-attachments/assets/f9a055f7-bdfd-4d6e-b1da-b96506807b44" />
