### PR TITLE
Fix(docs): Licence Naming Broken Links

### DIFF
--- a/content/en/docs/Userguide/BestPractices/license-naming.md
+++ b/content/en/docs/Userguide/BestPractices/license-naming.md
@@ -6,7 +6,7 @@ linkTitle: "License Naming"
 ## Guidelines
 Generally the license naming should conform with the SPDX Spec and the SPDX License List
 
-Please see the "License List Fields" from [<span style="color:red">&#8599;</span> https://spdx.org/spdx-license-list/license-list-overview#fields](https://spdx.org/spdx-license-list/license-list-overview#fields)
+Please see the "License List Fields" from [<span style="color:red">&#8599;</span> https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md](https://github.com/spdx/license-list-XML/blob/main/DOCS/license-fields.md)
 
 where there is especially for identifier:
 
@@ -110,4 +110,4 @@ The following text is not a license statement nor a reference to licensing but a
 ## Open Questions
 - How to deal with notice files
 
-(1) [<span style="color:red">&#8599;</span> https://spdx.org/spdx-specification-21-web-version](https://spdx.org/spdx-specification-21-web-version)
+(1) [<span style="color:red">&#8599;</span> https://spdx.dev/use/specifications/](https://spdx.dev/use/specifications/)

--- a/content/en/docs/Userguide/BestPractices/license-naming.md
+++ b/content/en/docs/Userguide/BestPractices/license-naming.md
@@ -110,4 +110,4 @@ The following text is not a license statement nor a reference to licensing but a
 ## Open Questions
 - How to deal with notice files
 
-(1) [<span style="color:red">&#8599;</span> https://spdx.dev/use/specifications/](https://spdx.dev/use/specifications/)
+(1) [<span style="color:red">&#8599;</span> https://spdx.github.io/spdx-spec/v2.3/](https://spdx.github.io/spdx-spec/v2.3/)


### PR DESCRIPTION
- This PR updates the documentation to correct the broken link to the license naming docs. The previous link was no longer functional, and this update ensures users can access the correct and updated links.

After: 

<img width="1710" alt="Screenshot 2025-04-13 at 10 34 56 PM" src="https://github.com/user-attachments/assets/32a3127e-dee4-41ed-b2b7-16296acfe9cb" />


Before: 

<img width="1710" alt="Screenshot 2025-04-14 at 9 40 43 AM" src="https://github.com/user-attachments/assets/022af94c-9e8c-4178-9eac-687c0c7daca0" />