### PR TITLE
📘 Fix typos and grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@
 </p>
 
 The website is based on the Hugo static page generator. 
-All relevant source files can be found at github/sw360.website (https://github.com/eclipse/sw360.website). 
-The page is published at eclipse.org/sw360 and build with a jenkins job, which is configured in a jenkins file in the repository of the website.
+All relevant source files can be found at [github.com/eclipse/sw360.website](https://github.com/eclipse/sw360.website).
+The page is published at eclipse.org/sw360 and built with a Jenkins job, which is configured in a jenkins file in the repository of the website.
 
 If you want to add content to the page, please checkout the git repository (https://github.com/eclipse/sw360.website.git) and add your content.
 
-The page will be build as soon as you push to upstream main branch. There is also a staging area at the Eclipse Foundation page at staging.eclipse.org/sw360, which is protected by your Eclipse Foundation user credentials and filled with the content that is fund at the staging branch in https://github.com/eclipse/sw360.website. If you want to check out your changes first, just push to the staging branch. The content is published the same way as with the main branch.
+The page will be build as soon as you push to upstream main branch. There is also a staging area at the Eclipse Foundation page at staging.eclipse.org/sw360, which is protected by your Eclipse Foundation user credentials and filled with the content that is found at the staging branch in https://github.com/eclipse/sw360.website. If you want to check out your changes first, just push to the staging branch. The content is published the same way as with the main branch.
 
-The jenkins instance is operated by the Eclipse Foundation and can be found here: https://jenkins.eclipse.org/sw360/job/sw360.website/.
-The result of the jenkins build is pushed to: http://git.eclipse.org/c/www.eclipse.org/sw360.git.
+The Jenkins instance is operated by the Eclipse Foundation and can be found here: https://jenkins.eclipse.org/sw360/job/sw360.website/.
+The result of the Jenkins build is pushed to: http://git.eclipse.org/c/www.eclipse.org/sw360.git.
 
-The jenkins jobs looks every 15 minutes after changes on the repository. If it detects changes it will start the hugo build and copy the generated static html files to git.eclipse.org. From there another job fetches the files and copies them to the actual static webspace of the Eclipse Foundation.
+The Jenkins job checks for changes in the repository every 15 minutes.If it detects changes it will start the Hugo build and copy the generated static html files to git.eclipse.org. From there another job fetches the files and copies them to the actual static webspace of the Eclipse Foundation.
 
 ## Table of Contents
 


### PR DESCRIPTION
### Summary

This PR improves the `README.md` by fixing minor grammar errors, typos, and inconsistencies, including:

- "build with a jenkins job" ➝ "built with a Jenkins job"
- "content that is fund" ➝ "content that is found"
- "jobs looks every 15 minutes" ➝ "job checks every 15 minutes"
- Capitalized proper nouns like Jenkins and Hugo
- Improved link formatting and sentence flow

### Why?

These changes enhance the clarity, professionalism, and readability of the documentation while maintaining the original structure.

Let me know if you'd like any further updates or modifications. Happy to contribute!
