### PR TITLE
fix(doc) : Replaced Outdated Links with updated links

### DIFF
--- a/content/en/docs/Development/Dev-External-Documents-with-CouchDB.md
+++ b/content/en/docs/Development/Dev-External-Documents-with-CouchDB.md
@@ -108,7 +108,7 @@ You might see the trick: the project document as well as the attachment document
 * null: if the value is null, the document which is identified by the key is included
 * { _id: "..." }: the document identified by the given id is included.
 To be clear: transitive inclusions will not work!
-**Note** See also https://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Linked_documents.
+**Note** See also [https://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Linked_documents](https://docs.couchdb.org/en/stable/ddocs/views/joins.html).
 
 ### Implementation with Ektorp
 https://github.com/eclipse/sw360/pull/596 show an implementation to transparently read such results from Couch-DB. It consists of:

--- a/content/en/docs/Development/Dev-Fossology-Integration.md
+++ b/content/en/docs/Development/Dev-Fossology-Integration.md
@@ -8,7 +8,7 @@ description: "Basis of communication between SW360 and FOSSology"
 Basic communication with the FOSSology server is done over an SSH connection: the fossology service of SW360 executes remote commands on the FOSSology server.
 
 The commands that are executed are the bash scripts found inside `src-fossology/src/main/resources/scripts/`, they are copied into the home directory of the ssh user (either manually or through the admin portlet).
-See [Setup of connection with Fossology](Fossology-Setup) for configuration details.
+See [Setup of connection with Fossology](https://eclipse.dev/sw360/docs/development/dev-fossology-integration/) for configuration details.
 
 ```
 \- src-fossology/src/main/resources/


### PR DESCRIPTION
- This PR updates the documentation to correct the broken link to the **CouchDB Views Documentation** & **SW360 Fossology Integration Setup**. The previous link was no longer functional, and this update ensures users can access the correct documentation.

Before : Fossology Integration Setup
![image](https://github.com/user-attachments/assets/54c74578-7997-4c41-a294-84652dc560a4) 
After : Fossology Integration Setup
![image](https://github.com/user-attachments/assets/96b76df5-7d3d-45d0-800b-530cc03f5bac)

Before : CouchDB Views Documentation
![Screenshot 2025-05-05 012534](https://github.com/user-attachments/assets/2f7e7dab-ebf6-4a35-bfbe-ebdd1ab3a7c3)

After : CouchDB Views Documentation
![image](https://github.com/user-attachments/assets/7001c701-e477-4d45-bc8a-0759b7233a01)

Issue #165 Solved.