### PR TITLE
fix(Native-19-Deploy): Fixed Apache tomcat download url

### DIFF
--- a/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-19-Natively.md
@@ -121,7 +121,7 @@ Get the latest version of [Apache Tomcat 11](https://tomcat.apache.org/download-
 and install it in `/opt`
 
 ```shell
-curl -L 'https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.4/bin/apache-tomcat-11.0.4.tar.gz' -o ~/Downloads/tomcat-11.0.4.tar.gz
+curl -L 'https://archive.apache.org/tomcat/tomcat-11/v11.0.8/bin/apache-tomcat-11.0.8.tar.gz' -o ~/Downloads/tomcat-11.0.8.tar.gz
 sudo tar -xzvf ~/Downloads/tomcat-11.0.4.tar.gz -C /opt
 sudo chown -R $USER:$USER /opt/apache-tomcat-11.0.4/
 ```


### PR DESCRIPTION
This PR fixes the download url of Apache tomcat with latest version.
 - Existing Issue: With the old command `curl -L 'https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.4/bin/apache-tomcat-11.0.4.tar.gz' -o ~/Downloads/tomcat-11.0.4.tar.gz` it downloads file of type `HTML` and `ASCII Text` (screenshot attached), forced to be saved as `.tar.gz` which fails in extraction command.
 
 
![image](https://github.com/user-attachments/assets/37803bf5-8bce-458b-8af6-1636265e2502)

With this PR, it'll download Apache tomcat in actual `.tar.gz` format (latest version i.e. `v11.0.8`).