### PR TITLE
fix: resolve duplicate speakers keys and improve Windows Docker compatibility

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -166,3 +166,49 @@ sections site wide to the original site's background svg.
   margin-left: auto; /* Push this element to the right */
   margin-right: 20px; /* Or your desired right margin */
 }
+
+// Hero section responsive images - Fix for mobile overflow (Issue #178)
+.hero-logo {
+  max-width: 100%;
+  height: auto;
+  width: 400px; // Default width for larger screens
+  
+  @media (max-width: 768px) {
+    width: 100%;
+    max-width: 300px;
+  }
+  
+  @media (max-width: 576px) {
+    width: 100%;
+    max-width: 280px;
+  }
+}
+
+.hero-screenshot {
+  max-width: 100%;
+  height: auto;
+  width: 500px; // Default width for larger screens
+  
+  @media (max-width: 768px) {
+    width: 100%;
+    max-width: 400px;
+  }
+  
+  @media (max-width: 576px) {
+    width: 100%;
+    max-width: 300px;
+  }
+}
+
+// Ensure hero section doesn't overflow on mobile
+.td-cover-block {
+  .row {
+    margin-right: 0;
+    margin-left: 0;
+  }
+  
+  @media (max-width: 576px) {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -7,15 +7,14 @@ linkTitle = "Eclipse SW360"
 <div class="row align-items-center">
   <div class="col-lg-6">
     <h4>
-      {{< figure src="/sw360/img/logos/logo_full.svg" width="400">}}
+      {{< figure src="/sw360/img/logos/logo_full.svg" class="hero-logo" >}}
       <p class="display-2 mb-0">
         Software supply chain management done right !
       </p>
     </h4>
   </div>
   <div class="col-lg-6 mt-5 mt-lg-3 d-sm-block" style="display: none">
-    {{< figure src="/sw360/img/sw360screenshots/sw360screenshot-home.png"
-    width="500" >}}
+    {{< figure src="/sw360/img/sw360screenshots/sw360screenshot-home.png" class="hero-screenshot" >}}
   </div>
 </div>
 

--- a/content/en/events/2017/open-source-summit-europe-2017.md
+++ b/content/en/events/2017/open-source-summit-europe-2017.md
@@ -8,7 +8,6 @@ format: talk
 tags:
   - talk
 speakers:
-speakers:
   - name: "Michael C. Jaeger"
     affiliation: "Project Lead, Siemens AG"
     about: "Michael C. Jaeger is one of the maintainers for Linux Foundation's FOSSology and Eclipse SW360 projects, both available on Github and both in the area of OSS handling w.r.t. license compliance and component management. At Siemens Corporate Technology in Munich, Germany, Michael works in several roles as project lead, software architect, trainer and consultant for distributed systems, server applications and their development with open source software."

--- a/content/en/events/2018/free-software-legal-licensing-workshop-2018.md
+++ b/content/en/events/2018/free-software-legal-licensing-workshop-2018.md
@@ -8,7 +8,6 @@ format: talk
 tags:
   - talk
 speakers:
-speakers:
   - name: "Michael C. Jaeger"
     affiliation: "Project Lead, Siemens AG"
     about: "Michael C. Jaeger is one of the maintainers for Linux Foundation's FOSSology and Eclipse SW360 projects, both available on Github and both in the area of OSS handling w.r.t. license compliance and component management. At Siemens Corporate Technology in Munich, Germany, Michael works in several roles as project lead, software architect, trainer and consultant for distributed systems, server applications and their development with open source software."

--- a/content/en/events/2018/yanking-the-chain-open-source.md
+++ b/content/en/events/2018/yanking-the-chain-open-source.md
@@ -8,7 +8,6 @@ format: talk
 tags:
   - talk
 speakers:
-speakers:
   - name: "Michael C. Jaeger"
     affiliation: "Project Lead, Siemens AG"
     about: "Michael C. Jaeger is one of the maintainers for Linux Foundation's FOSSology and Eclipse SW360 projects, both available on Github and both in the area of OSS handling w.r.t. license compliance and component management. At Siemens Corporate Technology in Munich, Germany, Michael works in several roles as project lead, software architect, trainer and consultant for distributed systems, server applications and their development with open source software."

--- a/docker_serve_local.sh
+++ b/docker_serve_local.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Disable path conversion for Windows Git Bash
+export MSYS_NO_PATHCONV=1
+
 echo "Create a template dir to allow Hugo properly clone the modules"
 mkdir -p themes/docsy
 
@@ -7,6 +10,7 @@ echo "Open local browser on port 1313"
 docker run \
     -v $PWD:/src \
     --rm \
+    --user root \
     --name sw360_website \
     -p 1313:1313 \
     "$@" \


### PR DESCRIPTION
This PR addresses two major blockers encountered while setting up the local development environment on Windows 11 using the provided Docker script:

1. Docker Volume Mount Failure (Windows / Git Bash)
   - Added MSYS_NO_PATHCONV=1 to disable automatic path conversion in Git Bash
   - Added --user root to resolve volume mount permission issues on Windows hosts

2. Build Failure: Duplicate Frontmatter Keys
   - Removed duplicate speakers: keys in 3 Markdown files

Fixes #179