### PR TITLE
docs: update pnpm install from v10 to v11

### DIFF
--- a/content/en/docs/Architecture/SW360-Frontend-Architecture.md
+++ b/content/en/docs/Architecture/SW360-Frontend-Architecture.md
@@ -83,7 +83,7 @@ The SW360 Frontend is a modern web application that replaces the legacy Liferay 
 | **Reactive Streams** | RxJS | 7.x |
 | **Linting/Formatting** | Biome | 2.x |
 | **E2E Testing** | Playwright | Latest |
-| **Package Manager** | pnpm | 10.x |
+| **Package Manager** | pnpm | 11.x |
 | **Runtime** | Node.js | 24.x (slim) |
 | **Bundler** | Turbopack (Next.js native) | Built-in |
 | **Git Hooks** | Husky + lint-staged + commitlint | Latest |

--- a/content/en/docs/Deployment/BareMetal/Deploy-20-Natively.md
+++ b/content/en/docs/Deployment/BareMetal/Deploy-20-Natively.md
@@ -196,7 +196,7 @@ pnpm is an advanced package manager for node dependencies and can be installed
 with the new npm installed above.
 
 ```shell
-npm install -g pnpm@latest-10
+npm install -g pnpm@latest-11
 ```
 
 ### 2.3. Clone and install frontend


### PR DESCRIPTION
Update all bare-metal deployment guides and the frontend architecture reference to install pnpm v11 instead of v10.

https://github.com/eclipse-sw360/sw360-frontend/pull/1761